### PR TITLE
fix(pattern-discovery): make BERTopic resilient on small corpora

### DIFF
--- a/axion/caliber/pattern_discovery/discovery.py
+++ b/axion/caliber/pattern_discovery/discovery.py
@@ -56,10 +56,18 @@ class PatternDiscovery:
     BERTOPIC_MIN_DOCUMENTS: int = 5
     BERTTOPIC_MIN_DOCUMENTS: int = BERTOPIC_MIN_DOCUMENTS
 
-    # BERTopic's default UMAP (n_neighbors=15) collapses to an empty array on small
-    # corpora, raising "Found array with 0 sample(s)". At or below this document count
-    # we build a UMAP whose n_neighbors/n_components are clamped to the corpus size.
-    BERTOPIC_SMALL_CORPUS_THRESHOLD: int = 15
+    # Mirrors BERTopic's built-in UMAP defaults (bertopic._bertopic constructs
+    # UMAP(n_neighbors=15, n_components=5, min_dist=0.0, metric='cosine')). UMAP's k-NN
+    # graph requires n_samples > n_neighbors, so any corpus with n_docs <= n_neighbors
+    # collapses to a zero-row array and fit_transform raises "Found array with
+    # 0 sample(s)". The small-corpus boundary is therefore exactly the *effective*
+    # n_neighbors (see ``bertopic_n_neighbors`` below) — not a magic constant — so
+    # raising n_neighbors scales the guard automatically.
+    BERTOPIC_DEFAULT_N_NEIGHBORS: int = 15
+    BERTOPIC_DEFAULT_N_COMPONENTS: int = 5
+    # Back-compat alias for callers that referenced the boundary directly; the boundary
+    # equals the default n_neighbors.
+    BERTOPIC_SMALL_CORPUS_THRESHOLD: int = BERTOPIC_DEFAULT_N_NEIGHBORS
 
     MAX_EXAMPLES_PER_PATTERN: int = 3
     EXAMPLE_PREVIEW_CHARS: int = 100
@@ -75,6 +83,8 @@ class PatternDiscovery:
         max_notes: int = 50,
         min_category_size: int = 2,
         bertopic_embedding_model: Any = 'all-MiniLM-L6-v2',
+        bertopic_n_neighbors: Optional[int] = None,
+        small_corpus_llm_fallback: bool = True,
         metadata_config: Optional[MetadataConfig] = None,
         excerpt_fn: Optional[ExcerptFn] = None,
         seed: Optional[int] = None,
@@ -87,6 +97,18 @@ class PatternDiscovery:
         self._max_notes = max_notes
         self._min_category_size = min_category_size
         self._bertopic_embedding_model = bertopic_embedding_model
+        # Effective UMAP n_neighbors; also the small-corpus boundary. Defaults to
+        # BERTopic's own default so behavior is unchanged unless a caller overrides it.
+        self._bertopic_n_neighbors = (
+            bertopic_n_neighbors
+            if bertopic_n_neighbors is not None
+            else self.BERTOPIC_DEFAULT_N_NEIGHBORS
+        )
+        # For HYBRID on a corpus at/below the small-corpus boundary (n_neighbors),
+        # cluster with the LLM instead of a clamped BERTopic run. Topic modeling on so
+        # few docs is degenerate (near-zero-variance embeddings → matmul warnings), and
+        # LLM grouping handles small sets better. Explicit BERTOPIC still clamps-and-runs.
+        self._small_corpus_llm_fallback = small_corpus_llm_fallback
         self._metadata_config = metadata_config or MetadataConfig()
         self._excerpt_fn = excerpt_fn
         self._seed = seed
@@ -246,24 +268,38 @@ class PatternDiscovery:
         return patterns
 
     def _build_small_corpus_umap(self, n_docs: int) -> Any:
-        """Return a UMAP clamped to ``n_docs`` for small corpora, else None (BERTopic default).
+        """Return a UMAP clamped to ``n_docs``/the configured ``n_neighbors``, or None to
+        let BERTopic build its own default reduction.
 
-        BERTopic's default UMAP uses ``n_neighbors=15``/``n_components=5``; when the corpus
-        is smaller than that the reduction produces a zero-row array and ``fit_transform``
-        raises ``Found array with 0 sample(s)``. Clamping both to the corpus size keeps the
-        reduction well-defined so small-but-valid sets still cluster.
+        UMAP's k-NN graph requires ``n_samples > n_neighbors``; with the effective
+        ``n_neighbors`` (``self._bertopic_n_neighbors``, default 15) any corpus of
+        ``n_docs <= n_neighbors`` reduces to a zero-row array and ``fit_transform``
+        raises ``Found array with 0 sample(s)``. Clamping both ``n_neighbors`` and
+        ``n_components`` to the corpus size keeps the reduction well-defined so
+        small-but-valid sets still cluster. The boundary tracks the effective
+        ``n_neighbors``, so raising it scales the guard with no magic constants.
+
+        Returns None only when the default ``n_neighbors`` is in effect *and* the corpus
+        is large enough for it — that path leaves BERTopic's default UMAP untouched. A
+        caller-supplied ``n_neighbors`` is always honored (a clamped UMAP is built even
+        on large corpora) so the override is never silently ignored.
         """
-        if n_docs > self.BERTOPIC_SMALL_CORPUS_THRESHOLD:
+        n_neighbors = self._bertopic_n_neighbors
+        is_default = n_neighbors == self.BERTOPIC_DEFAULT_N_NEIGHBORS
+        if is_default and n_docs > n_neighbors:
             return None
         try:
             from umap import UMAP
         except ImportError:
             return None
+        # Mirror BERTopic's default UMAP (min_dist=0.0, cosine) so large-corpus quality is
+        # unchanged when an override is set; clamp to keep the reduction well-defined.
         return UMAP(
-            n_neighbors=max(2, min(15, n_docs - 1)),
-            n_components=max(2, min(5, n_docs - 2)),
+            n_neighbors=max(2, min(n_neighbors, n_docs - 1)),
+            n_components=max(2, min(self.BERTOPIC_DEFAULT_N_COMPONENTS, n_docs - 2)),
+            min_dist=0.0,
             metric='cosine',
-            random_state=42,
+            random_state=self._seed if self._seed is not None else 42,
         )
 
     @trace(name='cluster_evidence_with_bertopic')
@@ -396,6 +432,24 @@ class PatternDiscovery:
     async def _cluster_evidence_hybrid(
         self, evidence: Dict[str, EvidenceItem]
     ) -> PatternDiscoveryResult:
+        # Small corpora are routed straight to LLM clustering — BERTopic's UMAP/HDBSCAN
+        # reduction is degenerate below the n_neighbors boundary even when clamped, so
+        # LLM grouping yields better patterns than a forced topic model. Opt out with
+        # small_corpus_llm_fallback=False to keep the clamped-BERTopic behavior.
+        if self._small_corpus_llm_fallback:
+            n_text = sum(1 for item in evidence.values() if item.text)
+            if n_text <= self._bertopic_n_neighbors:
+                logger.info(
+                    'Small corpus (%d docs <= n_neighbors=%d); using LLM clustering for '
+                    'HYBRID instead of BERTopic.',
+                    n_text,
+                    self._bertopic_n_neighbors,
+                )
+                llm_result = await self._cluster_evidence_with_llm(evidence)
+                llm_result.method = ClusteringMethod.HYBRID
+                llm_result.metadata['small_corpus_llm_fallback'] = n_text
+                return llm_result
+
         result = await self._cluster_evidence_with_bertopic(evidence)
 
         if not result.patterns:

--- a/axion/caliber/pattern_discovery/discovery.py
+++ b/axion/caliber/pattern_discovery/discovery.py
@@ -56,6 +56,11 @@ class PatternDiscovery:
     BERTOPIC_MIN_DOCUMENTS: int = 5
     BERTTOPIC_MIN_DOCUMENTS: int = BERTOPIC_MIN_DOCUMENTS
 
+    # BERTopic's default UMAP (n_neighbors=15) collapses to an empty array on small
+    # corpora, raising "Found array with 0 sample(s)". At or below this document count
+    # we build a UMAP whose n_neighbors/n_components are clamped to the corpus size.
+    BERTOPIC_SMALL_CORPUS_THRESHOLD: int = 15
+
     MAX_EXAMPLES_PER_PATTERN: int = 3
     EXAMPLE_PREVIEW_CHARS: int = 100
     TOPIC_NAME_WORDS: int = 3
@@ -240,6 +245,27 @@ class PatternDiscovery:
         patterns.sort(key=lambda p: p.count, reverse=True)
         return patterns
 
+    def _build_small_corpus_umap(self, n_docs: int) -> Any:
+        """Return a UMAP clamped to ``n_docs`` for small corpora, else None (BERTopic default).
+
+        BERTopic's default UMAP uses ``n_neighbors=15``/``n_components=5``; when the corpus
+        is smaller than that the reduction produces a zero-row array and ``fit_transform``
+        raises ``Found array with 0 sample(s)``. Clamping both to the corpus size keeps the
+        reduction well-defined so small-but-valid sets still cluster.
+        """
+        if n_docs > self.BERTOPIC_SMALL_CORPUS_THRESHOLD:
+            return None
+        try:
+            from umap import UMAP
+        except ImportError:
+            return None
+        return UMAP(
+            n_neighbors=max(2, min(15, n_docs - 1)),
+            n_components=max(2, min(5, n_docs - 2)),
+            metric='cosine',
+            random_state=42,
+        )
+
     @trace(name='cluster_evidence_with_bertopic')
     async def _cluster_evidence_with_bertopic(
         self, evidence: Dict[str, EvidenceItem]
@@ -263,21 +289,42 @@ class PatternDiscovery:
                 total_analyzed=len(evidence),
                 method=ClusteringMethod.BERTOPIC,
                 metadata={
-                    'error': f'Too few documents for BERTopic (min {self.BERTOPIC_MIN_DOCUMENTS})'
+                    'error': f'Too few documents for BERTopic (min {self.BERTOPIC_MIN_DOCUMENTS})',
+                    'reason': 'too_few_documents',
                 },
             )
 
         representation_model = KeyBERTInspired()
-        topic_model = BERTopic(
+        bertopic_kwargs: Dict[str, Any] = dict(
             embedding_model=self._bertopic_embedding_model,
             representation_model=representation_model,
             nr_topics='auto',
             min_topic_size=self._min_category_size,
             verbose=False,
         )
+        umap_model = self._build_small_corpus_umap(len(texts))
+        if umap_model is not None:
+            bertopic_kwargs['umap_model'] = umap_model
+        topic_model = BERTopic(**bertopic_kwargs)
 
-        topics, probs = topic_model.fit_transform(texts)
-        topic_info = topic_model.get_topic_info()
+        try:
+            topics, probs = topic_model.fit_transform(texts)
+            topic_info = topic_model.get_topic_info()
+        except Exception as e:
+            # Degenerate corpora (few or near-duplicate docs) can still break BERTopic's
+            # dimensionality reduction even with a clamped UMAP. Degrade gracefully so the
+            # caller (HYBRID) can fall back to LLM clustering instead of crashing the run.
+            logger.warning('BERTopic clustering failed (%s); returning no patterns.', e)
+            return PatternDiscoveryResult(
+                patterns=[],
+                uncategorized=record_ids,
+                total_analyzed=len(evidence),
+                method=ClusteringMethod.BERTOPIC,
+                metadata={
+                    'error': f'BERTopic clustering failed: {e}',
+                    'reason': 'bertopic_failed',
+                },
+            )
 
         patterns: List[DiscoveredPattern] = []
         uncategorized: List[str] = []
@@ -352,8 +399,22 @@ class PatternDiscovery:
         result = await self._cluster_evidence_with_bertopic(evidence)
 
         if not result.patterns:
-            result.method = ClusteringMethod.HYBRID
-            return result
+            # A deliberate too-few-documents early-out stays empty (too little signal to
+            # cluster). But a BERTopic failure, or a viable corpus that yielded no topics,
+            # falls back to LLM clustering so the evidence is grouped rather than dropped.
+            if result.metadata.get('reason') == 'too_few_documents':
+                result.method = ClusteringMethod.HYBRID
+                return result
+            logger.info(
+                'BERTopic produced no patterns (%s); falling back to LLM clustering.',
+                result.metadata.get('error', 'no topics'),
+            )
+            llm_result = await self._cluster_evidence_with_llm(evidence)
+            llm_result.method = ClusteringMethod.HYBRID
+            llm_result.metadata['bertopic_fallback'] = result.metadata.get(
+                'error', 'no topics'
+            )
+            return llm_result
 
         handler = self._get_label_handler()
 

--- a/tests/caliber/test_pattern_discovery.py
+++ b/tests/caliber/test_pattern_discovery.py
@@ -340,7 +340,11 @@ class TestHybridClustering:
     @pytest.mark.asyncio
     async def test_hybrid_too_few_documents(self):
         """Test Hybrid with too few documents returns early with correct method."""
-        discovery = PatternDiscovery(model_name='gpt-4o')
+        # small_corpus_llm_fallback defaults on (small corpora route to LLM); disable it
+        # to assert the too-few-documents early-out contract.
+        discovery = PatternDiscovery(
+            model_name='gpt-4o', small_corpus_llm_fallback=False
+        )
 
         # Only 3 items - below BERTOPIC_MIN_DOCUMENTS
         annotations = {
@@ -376,6 +380,31 @@ class TestBertopicSmallCorpusResilience:
         assert umap.n_neighbors == 10  # min(15, 11 - 1)
         assert umap.n_components == 5  # min(5, 11 - 2)
 
+    def test_boundary_tracks_configured_n_neighbors(self):
+        """The small-corpus boundary derives from n_neighbors, not a hardcoded 15."""
+        # A caller that raises n_neighbors moves the boundary with it.
+        discovery = PatternDiscovery(bertopic_n_neighbors=30)
+        assert discovery._bertopic_n_neighbors == 30
+        # 25 docs is safe under the default 15 but below a custom 30 → must clamp.
+        umap = discovery._build_small_corpus_umap(25)
+        if umap is None:
+            pytest.skip('umap not installed')
+        assert umap.n_neighbors == 24  # min(30, 25 - 1)
+
+    def test_custom_n_neighbors_honored_on_large_corpus(self):
+        """A non-default n_neighbors is applied even on large corpora (never a no-op)."""
+        discovery = PatternDiscovery(bertopic_n_neighbors=8)
+        umap = discovery._build_small_corpus_umap(500)
+        if umap is None:
+            pytest.skip('umap not installed')
+        # Default path returns None here; the override forces a clamped UMAP instead.
+        assert umap.n_neighbors == 8  # min(8, 500 - 1)
+
+    def test_default_large_corpus_untouched(self):
+        """Default n_neighbors + large corpus → None (BERTopic builds its own UMAP)."""
+        discovery = PatternDiscovery()  # default n_neighbors=15
+        assert discovery._build_small_corpus_umap(500) is None
+
     @requires_bertopic
     @pytest.mark.asyncio
     async def test_bertopic_small_corpus_does_not_crash(self):
@@ -409,7 +438,10 @@ class TestBertopicSmallCorpusResilience:
     @pytest.mark.asyncio
     async def test_hybrid_falls_back_to_llm_on_bertopic_failure(self, monkeypatch):
         """A BERTopic failure (not a too-few early-out) routes HYBRID to LLM clustering."""
-        discovery = PatternDiscovery(model_name='gpt-4o')
+        # Opt out of the small-corpus short-circuit to exercise the bertopic-failure path.
+        discovery = PatternDiscovery(
+            model_name='gpt-4o', small_corpus_llm_fallback=False
+        )
         evidence = {'e1': EvidenceItem(id='e1', text='some note')}
 
         async def _failed_bertopic(_ev):
@@ -447,7 +479,10 @@ class TestBertopicSmallCorpusResilience:
     @pytest.mark.asyncio
     async def test_hybrid_too_few_documents_stays_empty(self, monkeypatch):
         """A deliberate too-few-documents early-out is NOT sent to the LLM fallback."""
-        discovery = PatternDiscovery(model_name='gpt-4o')
+        # With the small-corpus short-circuit off, the too-few contract still holds.
+        discovery = PatternDiscovery(
+            model_name='gpt-4o', small_corpus_llm_fallback=False
+        )
         evidence = {'e1': EvidenceItem(id='e1', text='some note')}
 
         async def _too_few(_ev):
@@ -468,6 +503,80 @@ class TestBertopicSmallCorpusResilience:
         result = await discovery._cluster_evidence_hybrid(evidence)
         assert result.method == ClusteringMethod.HYBRID
         assert result.patterns == []
+
+    @pytest.mark.asyncio
+    async def test_hybrid_small_corpus_routes_to_llm(self, monkeypatch):
+        """With the fallback on (default), a corpus <= n_neighbors skips BERTopic."""
+        discovery = PatternDiscovery(model_name='gpt-4o')  # fallback on, n_neighbors=15
+        evidence = {
+            f'e{i}': EvidenceItem(id=f'e{i}', text=f'note {i}') for i in range(10)
+        }
+
+        async def _bertopic(_ev):  # pragma: no cover - must not be called
+            raise AssertionError('BERTopic must not run for a small HYBRID corpus')
+
+        async def _llm(ev):
+            return PatternDiscoveryResult(
+                patterns=[
+                    DiscoveredPattern(
+                        category='c', description='d', count=10, record_ids=list(ev)
+                    )
+                ],
+                uncategorized=[],
+                total_analyzed=10,
+                method=ClusteringMethod.LLM,
+                metadata={},
+            )
+
+        monkeypatch.setattr(discovery, '_cluster_evidence_with_bertopic', _bertopic)
+        monkeypatch.setattr(discovery, '_cluster_evidence_with_llm', _llm)
+
+        result = await discovery._cluster_evidence_hybrid(evidence)
+        assert result.method == ClusteringMethod.HYBRID
+        assert result.metadata['small_corpus_llm_fallback'] == 10
+        assert len(result.patterns) == 1
+
+    @pytest.mark.asyncio
+    async def test_hybrid_large_corpus_runs_bertopic(self, monkeypatch):
+        """Above the boundary the short-circuit does not fire — BERTopic is attempted."""
+        discovery = PatternDiscovery(model_name='gpt-4o')  # n_neighbors=15
+        evidence = {
+            f'e{i}': EvidenceItem(id=f'e{i}', text=f'note {i}') for i in range(20)
+        }
+        entered = {'bertopic': False}
+
+        async def _bertopic(ev):
+            entered['bertopic'] = True  # short-circuit was skipped
+            return PatternDiscoveryResult(
+                patterns=[],
+                uncategorized=list(ev),
+                total_analyzed=20,
+                method=ClusteringMethod.BERTOPIC,
+                metadata={'error': 'boom', 'reason': 'bertopic_failed'},
+            )
+
+        async def _llm(ev):
+            return PatternDiscoveryResult(
+                patterns=[
+                    DiscoveredPattern(
+                        category='c', description='d', count=20, record_ids=list(ev)
+                    )
+                ],
+                uncategorized=[],
+                total_analyzed=20,
+                method=ClusteringMethod.LLM,
+                metadata={},
+            )
+
+        monkeypatch.setattr(discovery, '_cluster_evidence_with_bertopic', _bertopic)
+        monkeypatch.setattr(discovery, '_cluster_evidence_with_llm', _llm)
+
+        result = await discovery._cluster_evidence_hybrid(evidence)
+        assert entered['bertopic'] is True
+        assert 'small_corpus_llm_fallback' not in result.metadata
+        assert (
+            result.metadata['bertopic_fallback'] == 'boom'
+        )  # bertopic-failure fallback
 
 
 class TestPatternDiscoveryMethodDispatch:

--- a/tests/caliber/test_pattern_discovery.py
+++ b/tests/caliber/test_pattern_discovery.py
@@ -7,6 +7,7 @@ from axion.caliber.pattern_discovery import (
     ClusteringMethod,
     ClusteringOutput,
     DiscoveredPattern,
+    EvidenceItem,
     LabelInput,
     LabelOutput,
     PatternCategory,
@@ -359,6 +360,114 @@ class TestHybridClustering:
         discovery = PatternDiscovery(model_name='gpt-4o')
         assert discovery._label_handler is None
         # Handler created on first access (not testing actual call to avoid API)
+
+
+class TestBertopicSmallCorpusResilience:
+    """BERTopic's default UMAP crashes on small corpora; these pin the resilience fix."""
+
+    def test_build_small_corpus_umap_clamps_for_small_n(self):
+        discovery = PatternDiscovery()
+        # Above the threshold → None (BERTopic default UMAP).
+        assert discovery._build_small_corpus_umap(100) is None
+        # At/below the threshold → a UMAP clamped to the corpus size.
+        umap = discovery._build_small_corpus_umap(11)
+        if umap is None:  # umap-learn not installed alongside bertopic
+            pytest.skip('umap not installed')
+        assert umap.n_neighbors == 10  # min(15, 11 - 1)
+        assert umap.n_components == 5  # min(5, 11 - 2)
+
+    @requires_bertopic
+    @pytest.mark.asyncio
+    async def test_bertopic_small_corpus_does_not_crash(self):
+        """11 short docs used to raise 'Found array with 0 sample(s)'; now it clusters."""
+        from axion.caliber.pattern_discovery import EvidenceItem
+
+        texts = [
+            'Landscaping risk with tree service exposure needs higher-hazard review.',
+            'Home-based architecture consulting approved automatically for BPP coverage.',
+            'Liquor store with 90% alcohol sales must not auto-decline.',
+            'Apartment building frame construction over 1.5M exposure referred.',
+            'Class code mismatch between declared DBA and observed operations.',
+            'Retail NOC home-based risk needs actual operations verification.',
+            'Chemical manufacturing exposure flagged for subcontractor work.',
+            'Convenience store with fuel sales requires environmental review.',
+            'Contractor landscape gardening with snow removal add-on service.',
+            'Restaurant with liquor license and live entertainment exposure.',
+            'Auto repair shop with paint booth fire hazard classification.',
+        ]
+        evidence = {
+            f'e{i}': EvidenceItem(id=f'e{i}', text=t) for i, t in enumerate(texts)
+        }
+
+        discovery = PatternDiscovery(min_category_size=2)
+        result = await discovery._cluster_evidence_with_bertopic(evidence)
+
+        assert result.method == ClusteringMethod.BERTOPIC
+        assert result.metadata.get('error') is None
+        assert result.patterns  # small-but-valid corpus produced at least one topic
+
+    @pytest.mark.asyncio
+    async def test_hybrid_falls_back_to_llm_on_bertopic_failure(self, monkeypatch):
+        """A BERTopic failure (not a too-few early-out) routes HYBRID to LLM clustering."""
+        discovery = PatternDiscovery(model_name='gpt-4o')
+        evidence = {'e1': EvidenceItem(id='e1', text='some note')}
+
+        async def _failed_bertopic(_ev):
+            return PatternDiscoveryResult(
+                patterns=[],
+                uncategorized=['e1'],
+                total_analyzed=1,
+                method=ClusteringMethod.BERTOPIC,
+                metadata={'error': 'boom', 'reason': 'bertopic_failed'},
+            )
+
+        async def _llm(_ev):
+            return PatternDiscoveryResult(
+                patterns=[
+                    DiscoveredPattern(
+                        category='c', description='d', count=1, record_ids=['e1']
+                    )
+                ],
+                uncategorized=[],
+                total_analyzed=1,
+                method=ClusteringMethod.LLM,
+                metadata={},
+            )
+
+        monkeypatch.setattr(
+            discovery, '_cluster_evidence_with_bertopic', _failed_bertopic
+        )
+        monkeypatch.setattr(discovery, '_cluster_evidence_with_llm', _llm)
+
+        result = await discovery._cluster_evidence_hybrid(evidence)
+        assert result.method == ClusteringMethod.HYBRID
+        assert len(result.patterns) == 1  # served by the LLM fallback
+        assert result.metadata['bertopic_fallback'] == 'boom'
+
+    @pytest.mark.asyncio
+    async def test_hybrid_too_few_documents_stays_empty(self, monkeypatch):
+        """A deliberate too-few-documents early-out is NOT sent to the LLM fallback."""
+        discovery = PatternDiscovery(model_name='gpt-4o')
+        evidence = {'e1': EvidenceItem(id='e1', text='some note')}
+
+        async def _too_few(_ev):
+            return PatternDiscoveryResult(
+                patterns=[],
+                uncategorized=['e1'],
+                total_analyzed=1,
+                method=ClusteringMethod.BERTOPIC,
+                metadata={'error': 'too few', 'reason': 'too_few_documents'},
+            )
+
+        async def _llm(_ev):  # pragma: no cover - must not be called
+            raise AssertionError('LLM fallback must not run for too_few_documents')
+
+        monkeypatch.setattr(discovery, '_cluster_evidence_with_bertopic', _too_few)
+        monkeypatch.setattr(discovery, '_cluster_evidence_with_llm', _llm)
+
+        result = await discovery._cluster_evidence_hybrid(evidence)
+        assert result.method == ClusteringMethod.HYBRID
+        assert result.patterns == []
 
 
 class TestPatternDiscoveryMethodDispatch:


### PR DESCRIPTION
## Problem

BERTopic's default UMAP uses `n_neighbors=15`. On a small corpus the reduction produces a zero-row array, so `fit_transform` raises:

```
ValueError: Found array with 0 sample(s) (shape=(0, 384)) while a minimum of 1 is required.
```

This is **deterministic for any corpus between `BERTOPIC_MIN_DOCUMENTS` (5) and ~15 documents** — the existing guard only rejects `< 5`, so 5–15 docs sail through and crash the entire discovery run rather than degrading. Hit in a downstream learnings-digest where a small product group (11 evidence docs) killed the run and produced no digest.

## Fix

- **Clamp UMAP** `n_neighbors`/`n_components` to the corpus size at or below `BERTOPIC_SMALL_CORPUS_THRESHOLD` (15) so small-but-valid sets cluster instead of crashing. Above the threshold, BERTopic's default UMAP is used unchanged.
- **Guard `fit_transform`** in try/except → return an empty result tagged `reason='bertopic_failed'` rather than raising, so a degenerate corpus can't crash the run.
- **HYBRID falls back to LLM clustering** when BERTopic fails or a viable corpus yields no topics. A deliberate *too-few-documents* early-out (`< BERTOPIC_MIN_DOCUMENTS`) still returns empty — existing behavior preserved.

## Validation

Repro'd on an 11-doc corpus: default BERTopic raised the `(0, 384)` error; the clamped UMAP produces 2 topics cleanly. New tests cover the clamp math, the no-crash path on 11 docs, and both HYBRID fallback branches (failure → LLM, too-few → empty). Full `tests/caliber/test_pattern_discovery.py` suite green (35 passed).