### PR TITLE
feat(pattern-discovery): deterministic clustering + corpus-scaled calibration

### DIFF
--- a/axion/caliber/pattern_discovery/discovery.py
+++ b/axion/caliber/pattern_discovery/discovery.py
@@ -14,6 +14,7 @@ from axion.caliber.pattern_discovery._utils import (
     format_metadata_header,
 )
 from axion.caliber.pattern_discovery.handlers import (
+    DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION,
     ClusteringOutput,
     EvidenceClusteringHandler,
     EvidenceClusteringInput,
@@ -21,6 +22,7 @@ from axion.caliber.pattern_discovery.handlers import (
     LabelInput,
     LabelOutput,
     LabelRefinementHandler,
+    default_evidence_clustering_instruction,
 )
 from axion.caliber.pattern_discovery.models import (
     ClusteringMethod,
@@ -114,20 +116,33 @@ class PatternDiscovery:
         self._seed = seed
         self.tracer = init_tracer('base', tracer=tracer)
 
-        # Lazily initialized handlers
-        self._evidence_clustering_handler: Optional[EvidenceClusteringHandler] = None
+        # Lazily initialized handlers. Clustering handlers are cached per rendered
+        # instruction: with the default instruction the category range scales with
+        # corpus size (see ``evidence_category_range``), so different corpus sizes can
+        # need different handler instances within one PatternDiscovery lifetime.
+        self._evidence_clustering_handlers: Dict[str, EvidenceClusteringHandler] = {}
         self._label_handler: Optional[LabelRefinementHandler] = None
 
-    def _get_evidence_clustering_handler(self) -> EvidenceClusteringHandler:
-        if self._evidence_clustering_handler is None:
-            self._evidence_clustering_handler = EvidenceClusteringHandler(
+    def _get_evidence_clustering_handler(
+        self, n_items: Optional[int] = None
+    ) -> EvidenceClusteringHandler:
+        if self._instruction is not None:
+            instruction = self._instruction  # caller-supplied: never rescaled
+        elif n_items is not None:
+            instruction = default_evidence_clustering_instruction(n_items)
+        else:
+            instruction = DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION
+        handler = self._evidence_clustering_handlers.get(instruction)
+        if handler is None:
+            handler = EvidenceClusteringHandler(
                 model_name=self._model_name,
                 llm=self._llm,
                 llm_provider=self._llm_provider,
-                instruction=self._instruction,
+                instruction=instruction,
                 tracer=self.tracer,
             )
-        return self._evidence_clustering_handler
+            self._evidence_clustering_handlers[instruction] = handler
+        return handler
 
     def _get_label_handler(self) -> LabelRefinementHandler:
         if self._label_handler is None:
@@ -226,7 +241,7 @@ class PatternDiscovery:
             notes.append(EvidenceNote(item_id=eid, text=item.text, context=context))
 
         input_data = EvidenceClusteringInput(items=notes)
-        handler = self._get_evidence_clustering_handler()
+        handler = self._get_evidence_clustering_handler(n_items=len(notes))
         output: ClusteringOutput = await handler.execute(input_data)
 
         patterns = self._output_to_patterns(output, items_with_text)
@@ -267,33 +282,35 @@ class PatternDiscovery:
         patterns.sort(key=lambda p: p.count, reverse=True)
         return patterns
 
-    def _build_small_corpus_umap(self, n_docs: int) -> Any:
-        """Return a UMAP clamped to ``n_docs``/the configured ``n_neighbors``, or None to
-        let BERTopic build its own default reduction.
+    def _build_umap(self, n_docs: int) -> Any:
+        """Return a seeded UMAP mirroring BERTopic's defaults, clamped to ``n_docs``.
 
-        UMAP's k-NN graph requires ``n_samples > n_neighbors``; with the effective
-        ``n_neighbors`` (``self._bertopic_n_neighbors``, default 15) any corpus of
+        Always building the UMAP (rather than deferring to BERTopic's own on large
+        corpora) exists for one reason: BERTopic constructs its default UMAP with
+        ``random_state=None``, so cluster membership is stochastic run-to-run.
+        Downstream recurrence thresholds then kill/birth whole learnings on boundary
+        jitter. Seeding with ``self._seed`` (or 42 when unseeded) makes the reduction
+        deterministic; every other parameter matches BERTopic's built-in default
+        (``n_neighbors=15, n_components=5, min_dist=0.0, metric='cosine'``), so
+        clustering quality is unchanged.
+
+        Clamping handles small corpora: UMAP's k-NN graph requires
+        ``n_samples > n_neighbors``; with the effective ``n_neighbors``
+        (``self._bertopic_n_neighbors``, default 15) any corpus of
         ``n_docs <= n_neighbors`` reduces to a zero-row array and ``fit_transform``
         raises ``Found array with 0 sample(s)``. Clamping both ``n_neighbors`` and
         ``n_components`` to the corpus size keeps the reduction well-defined so
         small-but-valid sets still cluster. The boundary tracks the effective
         ``n_neighbors``, so raising it scales the guard with no magic constants.
 
-        Returns None only when the default ``n_neighbors`` is in effect *and* the corpus
-        is large enough for it — that path leaves BERTopic's default UMAP untouched. A
-        caller-supplied ``n_neighbors`` is always honored (a clamped UMAP is built even
-        on large corpora) so the override is never silently ignored.
+        Returns None only when ``umap`` is not importable (BERTopic then falls back to
+        its own default reduction — unseeded, but at least functional).
         """
-        n_neighbors = self._bertopic_n_neighbors
-        is_default = n_neighbors == self.BERTOPIC_DEFAULT_N_NEIGHBORS
-        if is_default and n_docs > n_neighbors:
-            return None
         try:
             from umap import UMAP
         except ImportError:
             return None
-        # Mirror BERTopic's default UMAP (min_dist=0.0, cosine) so large-corpus quality is
-        # unchanged when an override is set; clamp to keep the reduction well-defined.
+        n_neighbors = self._bertopic_n_neighbors
         return UMAP(
             n_neighbors=max(2, min(n_neighbors, n_docs - 1)),
             n_components=max(2, min(self.BERTOPIC_DEFAULT_N_COMPONENTS, n_docs - 2)),
@@ -301,6 +318,9 @@ class PatternDiscovery:
             metric='cosine',
             random_state=self._seed if self._seed is not None else 42,
         )
+
+    # Back-compat alias — the method previously only produced a UMAP for small corpora.
+    _build_small_corpus_umap = _build_umap
 
     @trace(name='cluster_evidence_with_bertopic')
     async def _cluster_evidence_with_bertopic(
@@ -338,7 +358,7 @@ class PatternDiscovery:
             min_topic_size=self._min_category_size,
             verbose=False,
         )
-        umap_model = self._build_small_corpus_umap(len(texts))
+        umap_model = self._build_umap(len(texts))
         if umap_model is not None:
             bertopic_kwargs['umap_model'] = umap_model
         topic_model = BERTopic(**bertopic_kwargs)

--- a/axion/caliber/pattern_discovery/handlers.py
+++ b/axion/caliber/pattern_discovery/handlers.py
@@ -81,9 +81,9 @@ Guidelines:
 - Notes that don't fit any clear pattern should be marked as uncategorized
 """
 
-DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION = """You are an expert at analyzing text evidence and discovering patterns.
+DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION_TEMPLATE = """You are an expert at analyzing text evidence and discovering patterns.
 
-Analyze the provided items and group them into 3-6 meaningful categories based on common themes, issues, or patterns.
+Analyze the provided items and group them into {category_range} meaningful categories based on common themes, issues, or patterns.
 
 For each category:
 1. Provide a short, descriptive name (2-4 words)
@@ -97,6 +97,31 @@ Guidelines:
 - Items that don't fit any clear pattern should be marked as uncategorized
 """
 
+
+def evidence_category_range(n_items: int) -> str:
+    """Category-count range scaled to corpus size, e.g. ``'3-6'``.
+
+    A fixed "3-6 categories" forces the same granularity onto a 10-item corpus and a
+    170-item one, over-merging large corpora. Roughly one category per 5-12 items,
+    floored at 2 and capped at 15, with the span kept >= 2 so the LLM has latitude.
+    """
+    lo = min(15, max(2, n_items // 12))
+    hi = min(15, max(lo + 2, n_items // 5))
+    return f'{lo}-{hi}'
+
+
+def default_evidence_clustering_instruction(n_items: int) -> str:
+    """Render the evidence-clustering instruction with a corpus-scaled category range."""
+    return DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION_TEMPLATE.format(
+        category_range=evidence_category_range(n_items)
+    )
+
+
+# Back-compat constant: the historical fixed-range instruction.
+DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION = (
+    DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION_TEMPLATE.format(category_range='3-6')
+)
+
 DEFAULT_DISTILLATION_INSTRUCTION_TEMPLATE = """You are an expert at synthesizing clusters of related evidence into actionable learnings.
 
 Given a cluster of related items, produce one or more learning artifacts that capture the key insight.
@@ -105,7 +130,11 @@ For each learning:
 1. Title: A concise 2-8 word actionable title
 2. Content: A synthesized insight in prose form
 3. Tags: Categorical tags for organization
-4. Confidence: 0.0-1.0 reflecting how well-supported the learning is
+4. Confidence: 0.0-1.0, anchored to the supporting evidence:
+   - 0.9+: >= 10 consistent supporting items, no counterexamples
+   - 0.75-0.89: 5-9 supporting items, at most weak counterexamples
+   - 0.6-0.74: 3-4 supporting items, or notable counterexamples
+   - < 0.6: weak or mixed support
 5. Supporting item IDs: ONLY cite item_ids from the provided cluster's item_ids list
 6. Recommended actions: Actionable bullet points (at least one for high-confidence learnings)
 7. Counterexamples: Item IDs that contradict the main pattern (if any, from this cluster only)

--- a/axion/caliber/pattern_discovery/pipeline.py
+++ b/axion/caliber/pattern_discovery/pipeline.py
@@ -120,6 +120,10 @@ class EvidencePipeline:
         tag_normalizer: Optional[Callable[[List[str]], List[str]]] = None,
         bertopic_embedding_model: Any = 'all-MiniLM-L6-v2',
         tracer: Optional[Any] = None,
+        # New params stay at the end so existing positional callers are unaffected.
+        cluster_model_name: Optional[str] = None,
+        cluster_llm=None,
+        cluster_llm_provider: Optional[str] = None,
     ) -> None:
         self._method = method
         self._recurrence_threshold = recurrence_threshold
@@ -140,14 +144,18 @@ class EvidencePipeline:
         self._deduper = deduper
         self._tag_normalizer = tag_normalizer or default_tag_normalizer
 
-        # Build default strategies if not provided
+        # Build default strategies if not provided.
+        # cluster_llm / cluster_model_name / cluster_llm_provider let clustering (and
+        # BERTopic label refinement) run on a different model than distillation — e.g.
+        # a temperature-0 model for stable cluster assignments while distillation stays
+        # on a fixed-temperature reasoning model. Unset -> both share the main llm.
         if clusterer is not None:
             self._clusterer: EvidenceClusterer = clusterer
         else:
             discovery = PatternDiscovery(
-                model_name=model_name,
-                llm=llm,
-                llm_provider=llm_provider,
+                model_name=cluster_model_name or model_name,
+                llm=cluster_llm if cluster_llm is not None else llm,
+                llm_provider=cluster_llm_provider or llm_provider,
                 instruction=clustering_instruction,
                 max_notes=max_items,
                 min_category_size=min_category_size,

--- a/tests/caliber/test_pattern_discovery.py
+++ b/tests/caliber/test_pattern_discovery.py
@@ -369,12 +369,10 @@ class TestHybridClustering:
 class TestBertopicSmallCorpusResilience:
     """BERTopic's default UMAP crashes on small corpora; these pin the resilience fix."""
 
-    def test_build_small_corpus_umap_clamps_for_small_n(self):
+    def test_build_umap_clamps_for_small_n(self):
         discovery = PatternDiscovery()
-        # Above the threshold → None (BERTopic default UMAP).
-        assert discovery._build_small_corpus_umap(100) is None
-        # At/below the threshold → a UMAP clamped to the corpus size.
-        umap = discovery._build_small_corpus_umap(11)
+        # At/below the boundary → a UMAP clamped to the corpus size.
+        umap = discovery._build_umap(11)
         if umap is None:  # umap-learn not installed alongside bertopic
             pytest.skip('umap not installed')
         assert umap.n_neighbors == 10  # min(15, 11 - 1)
@@ -386,7 +384,7 @@ class TestBertopicSmallCorpusResilience:
         discovery = PatternDiscovery(bertopic_n_neighbors=30)
         assert discovery._bertopic_n_neighbors == 30
         # 25 docs is safe under the default 15 but below a custom 30 → must clamp.
-        umap = discovery._build_small_corpus_umap(25)
+        umap = discovery._build_umap(25)
         if umap is None:
             pytest.skip('umap not installed')
         assert umap.n_neighbors == 24  # min(30, 25 - 1)
@@ -394,16 +392,40 @@ class TestBertopicSmallCorpusResilience:
     def test_custom_n_neighbors_honored_on_large_corpus(self):
         """A non-default n_neighbors is applied even on large corpora (never a no-op)."""
         discovery = PatternDiscovery(bertopic_n_neighbors=8)
-        umap = discovery._build_small_corpus_umap(500)
+        umap = discovery._build_umap(500)
         if umap is None:
             pytest.skip('umap not installed')
-        # Default path returns None here; the override forces a clamped UMAP instead.
         assert umap.n_neighbors == 8  # min(8, 500 - 1)
 
-    def test_default_large_corpus_untouched(self):
-        """Default n_neighbors + large corpus → None (BERTopic builds its own UMAP)."""
-        discovery = PatternDiscovery()  # default n_neighbors=15
-        assert discovery._build_small_corpus_umap(500) is None
+    def test_default_large_corpus_seeded(self):
+        """Default n_neighbors + large corpus → a UMAP mirroring BERTopic's defaults but
+        seeded. BERTopic's own default UMAP has random_state=None → stochastic clusters
+        run-to-run; this pins the determinism fix."""
+        discovery = PatternDiscovery()  # default n_neighbors=15, no seed
+        umap = discovery._build_umap(500)
+        if umap is None:
+            pytest.skip('umap not installed')
+        assert umap.n_neighbors == 15
+        assert umap.n_components == 5
+        assert umap.min_dist == 0.0
+        assert umap.metric == 'cosine'
+        assert umap.random_state == 42  # unseeded discovery still deterministic
+
+    def test_umap_uses_configured_seed(self):
+        discovery = PatternDiscovery(seed=7)
+        umap = discovery._build_umap(500)
+        if umap is None:
+            pytest.skip('umap not installed')
+        assert umap.random_state == 7
+
+    def test_build_small_corpus_umap_alias(self):
+        """Back-compat: the old method name still resolves to the new builder."""
+        discovery = PatternDiscovery()
+        assert PatternDiscovery._build_small_corpus_umap is PatternDiscovery._build_umap
+        umap = discovery._build_small_corpus_umap(11)
+        if umap is None:
+            pytest.skip('umap not installed')
+        assert umap.n_neighbors == 10
 
     @requires_bertopic
     @pytest.mark.asyncio

--- a/tests/caliber/test_pattern_discovery_determinism.py
+++ b/tests/caliber/test_pattern_discovery_determinism.py
@@ -1,0 +1,123 @@
+"""Determinism + calibration knobs for pattern discovery.
+
+Covers the corpus-scaled clustering category range, the per-range clustering-handler
+cache, the ``cluster_llm`` split on ``EvidencePipeline`` (clustering on one model,
+distillation on another), and the evidence-anchored confidence rubric in the
+distillation instruction. The seeded-UMAP determinism fix is pinned in
+``test_pattern_discovery.py::TestBertopicSmallCorpusResilience``.
+"""
+
+import pytest
+
+from axion.caliber.pattern_discovery.discovery import PatternDiscovery
+from axion.caliber.pattern_discovery.handlers import (
+    DEFAULT_DISTILLATION_INSTRUCTION,
+    DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION,
+    default_evidence_clustering_instruction,
+    evidence_category_range,
+)
+from axion.caliber.pattern_discovery.pipeline import EvidencePipeline
+
+
+class _FakeLLM:
+    """Minimal runnable satisfying the handler LLM validation."""
+
+    model = 'fake-model'
+
+    async def acomplete(self, *args, **kwargs):  # pragma: no cover - never invoked
+        raise AssertionError('fake LLM must not be called in these tests')
+
+
+class TestEvidenceCategoryRange:
+    """The clustering category range scales with corpus size (was hardcoded 3-6)."""
+
+    @pytest.mark.parametrize(
+        ('n_items', 'expected'),
+        [
+            (5, '2-4'),  # tiny corpus: floor lo at 2, keep span >= 2
+            (10, '2-4'),
+            (30, '2-6'),
+            (54, '4-10'),  # the Package-digest corpus size
+            (100, '8-15'),
+            (170, '14-15'),  # the BOP-digest corpus size; hi capped at 15
+            (1000, '15-15'),  # lo would exceed the cap without min()
+        ],
+    )
+    def test_range_values(self, n_items, expected):
+        assert evidence_category_range(n_items) == expected
+
+    def test_lo_never_exceeds_hi(self):
+        for n in range(2, 500):
+            lo, hi = map(int, evidence_category_range(n).split('-'))
+            assert 2 <= lo <= hi <= 15, f'n={n} produced {lo}-{hi}'
+
+    def test_rendered_instruction_contains_range(self):
+        instruction = default_evidence_clustering_instruction(100)
+        assert 'group them into 8-15 meaningful categories' in instruction
+
+    def test_backcompat_constant_keeps_fixed_range(self):
+        assert 'group them into 3-6 meaningful categories' in (
+            DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION
+        )
+
+
+class TestScaledClusteringHandler:
+    """PatternDiscovery renders the corpus-scaled instruction into its handler."""
+
+    def test_handler_gets_scaled_instruction(self):
+        discovery = PatternDiscovery(llm=_FakeLLM())
+        handler = discovery._get_evidence_clustering_handler(n_items=100)
+        assert 'group them into 8-15 meaningful categories' in handler.instruction
+
+    def test_handlers_cached_per_range(self):
+        discovery = PatternDiscovery(llm=_FakeLLM())
+        h_small = discovery._get_evidence_clustering_handler(n_items=10)
+        h_small_again = discovery._get_evidence_clustering_handler(n_items=11)
+        h_large = discovery._get_evidence_clustering_handler(n_items=100)
+        # 10 and 11 items render the same range -> same cached handler.
+        assert h_small is h_small_again
+        assert h_small is not h_large
+
+    def test_custom_instruction_never_rescaled(self):
+        custom = 'Cluster these however you like.'
+        discovery = PatternDiscovery(llm=_FakeLLM(), instruction=custom)
+        handler = discovery._get_evidence_clustering_handler(n_items=100)
+        assert handler.instruction == custom
+
+
+class TestClusterLLMSplit:
+    """EvidencePipeline can run clustering and distillation on different models."""
+
+    def test_cluster_llm_routes_to_discovery_only(self):
+        cluster_llm = _FakeLLM()
+        distill_llm = _FakeLLM()
+        pipeline = EvidencePipeline(llm=distill_llm, cluster_llm=cluster_llm)
+        assert pipeline._clusterer._discovery._llm is cluster_llm
+        assert pipeline._writer._handler.llm is distill_llm
+
+    def test_default_shares_main_llm(self):
+        llm = _FakeLLM()
+        pipeline = EvidencePipeline(llm=llm)
+        assert pipeline._clusterer._discovery._llm is llm
+        assert pipeline._writer._handler.llm is llm
+
+    def test_cluster_model_name_routes_to_discovery_only(self):
+        pipeline = EvidencePipeline(
+            llm=_FakeLLM(),
+            cluster_llm=_FakeLLM(),
+            model_name='gpt-5.2',
+            cluster_model_name='gpt-4.1',
+        )
+        assert pipeline._clusterer._discovery._model_name == 'gpt-4.1'
+        assert pipeline._writer._handler.model_name == 'gpt-5.2'
+
+
+class TestConfidenceRubric:
+    """The distillation instruction anchors confidence to evidence counts."""
+
+    def test_rubric_present(self):
+        assert '0.9+: >= 10 consistent supporting items' in (
+            DEFAULT_DISTILLATION_INSTRUCTION
+        )
+        assert '0.75-0.89: 5-9 supporting items' in DEFAULT_DISTILLATION_INSTRUCTION
+        assert '< 0.6: weak or mixed support' in DEFAULT_DISTILLATION_INSTRUCTION


### PR DESCRIPTION
## Why

Weekly digests built on `EvidencePipeline` (echo-workbench Athena learnings digest) swing wildly run-to-run — 1 vs 13 candidates on the same data window — with confidences clustered on the 0.75/0.85 round-number anchors. Diagnosed causes, all fixed here:

1. **Unseeded UMAP.** BERTopic constructs its default UMAP with `random_state=None`, so cluster membership is stochastic every run. Downstream `recurrence_threshold` pre-filtering then kills/births whole candidates on boundary jitter.
2. **Hardcoded "3-6 categories"** in the LLM-clustering instruction regardless of corpus size (54 or 170 docs → same 3-6), over-merging large corpora.
3. **Clustering forced onto the distillation model.** Fixed-temperature models (e.g. gpt-5.2 at temp 1.0) re-roll cluster assignments each run; callers had no way to split clustering onto a temp-0 model.
4. **Confidence = uncalibrated LLM self-rating** ("0.0-1.0 reflecting how well-supported") → round-number anchoring.

## What

- **Seeded UMAP on every path** (`discovery.py`): `_build_small_corpus_umap` → `_build_umap` (back-compat alias kept). Always returns a UMAP mirroring BERTopic's own defaults (`n_neighbors=15, n_components=5, min_dist=0.0, cosine`) with `random_state=self._seed or 42`, clamped for small corpora exactly as before (PR #84 behavior preserved). Only observable change vs BERTopic default: determinism.
- **Corpus-scaled category range** (`handlers.py`, `discovery.py`): `evidence_category_range(n)` → roughly one category per 5-12 items, bounds [2, 15]; rendered through new `DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION_TEMPLATE` with a `{category_range}` slot. Clustering handlers cached per rendered instruction. Caller-supplied `instruction` is never rescaled; the old `DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION` constant keeps its fixed 3-6.
- **`cluster_llm` / `cluster_model_name` / `cluster_llm_provider` on `EvidencePipeline`** (`pipeline.py`): routes the internal `PatternDiscovery` (clustering + BERTopic label refinement) to a different model while `DistillationHandler` keeps the main `llm`. Unset → both share the main llm (unchanged).
- **Evidence-anchored confidence rubric** in `DEFAULT_DISTILLATION_INSTRUCTION_TEMPLATE`: `0.9+`: ≥10 consistent items no counterexamples; `0.75-0.89`: 5-9; `0.6-0.74`: 3-4 or notable counterexamples; `<0.6`: weak/mixed.

## Tests

`tests/caliber/`: 258 passed (was 239 baseline + new coverage).

- New `test_pattern_discovery_determinism.py`: range values incl. the real digest corpus sizes (54 → 4-10, 170 → 14-15), lo≤hi invariant swept n=2..500, per-range handler cache, custom-instruction never rescaled, cluster_llm routing (clustering vs distillation get different fakes), rubric presence.
- Updated `TestBertopicSmallCorpusResilience`: large-corpus default now asserts a seeded UMAP mirroring BERTopic defaults (was `None`); new seed-propagation + back-compat-alias tests.

## Compatibility

**API: fully backward-compatible.** No signatures removed or reordered; the three new `EvidencePipeline` params sit at the end of `__init__` so positional callers are unaffected. `_build_small_corpus_umap` kept as an alias. Full test suite: 1354 passed (includes `reporting/insight_extractor`, the other internal `EvidencePipeline` consumer).

**Behavior: three intentional default-path changes** (all opt-out via existing params):
1. Large-corpus BERTopic runs are now deterministic. Results were random before, so no caller could depend on exact outputs — but note a seeded UMAP forces `n_jobs=1`, so UMAP loses thread parallelism on big corpora (umap-learn emits a warning saying exactly this). Modest slowdown on large corpora is the price of reproducibility.
2. Default LLM-clustering instruction scales its category range with corpus size (≤ ~50 items under the default `max_notes` → ranges like 2-4 … 4-10 instead of fixed 3-6). Any caller-supplied `instruction` is untouched, and the `DEFAULT_EVIDENCE_CLUSTERING_INSTRUCTION` constant keeps the literal 3-6 text.
3. Default distillation instruction now carries the confidence rubric, so confidence distributions will shift (that's the point). Caller-supplied `distillation_instruction` untouched.

Private internals: the single `_evidence_clustering_handler` attribute became a per-instruction `_evidence_clustering_handlers` dict — only external code monkeypatching that private attr would notice.
