### PR TITLE
fix(tracing): warn once per process on missing Langfuse setup

### DIFF
--- a/axion/_core/tracing/langfuse/tracer.py
+++ b/axion/_core/tracing/langfuse/tracer.py
@@ -69,6 +69,12 @@ class LangfuseTracer(BaseTracer):
     _shared_client: Optional[Langfuse] = None
     _shared_client_key: Optional[tuple] = None
 
+    # Warn about missing setup once per process, not once per tracer — metric
+    # instantiation constructs a tracer each time, and repeating the same
+    # warning for every metric is pure noise (subsequent hits log at DEBUG).
+    _warned_not_installed: bool = False
+    _warned_no_credentials: bool = False
+
     def __init__(
         self,
         metadata_type: str = 'default',
@@ -189,14 +195,24 @@ class LangfuseTracer(BaseTracer):
     def _initialize_client(self) -> None:
         """Initialize the Langfuse client."""
         if not LANGFUSE_AVAILABLE:
-            logger.warning('langfuse package not installed. Run: pip install langfuse')
+            message = 'langfuse package not installed. Run: pip install langfuse'
+            if LangfuseTracer._warned_not_installed:
+                logger.debug(message)
+            else:
+                LangfuseTracer._warned_not_installed = True
+                logger.warning(message)
             return
 
         if not self._public_key or not self._secret_key:
-            logger.warning(
+            message = (
                 'Langfuse credentials not configured. '
                 'Set LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY environment variables.'
             )
+            if LangfuseTracer._warned_no_credentials:
+                logger.debug(message)
+            else:
+                LangfuseTracer._warned_no_credentials = True
+                logger.warning(message)
             return
 
         try:

--- a/tests/_core/tracing/langfuse/test_warn_once.py
+++ b/tests/_core/tracing/langfuse/test_warn_once.py
@@ -1,0 +1,59 @@
+"""The missing-setup warnings fire once per process, then drop to DEBUG.
+
+A tracer is constructed per metric instantiation; without the once-guard the
+same 'Langfuse credentials not configured' warning repeats for every metric
+in a run (pure noise for deliberately-untraced deterministic scoring).
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from axion._core.tracing.langfuse.tracer import LangfuseTracer
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_flags():
+    LangfuseTracer._warned_not_installed = False
+    LangfuseTracer._warned_no_credentials = False
+    yield
+    LangfuseTracer._warned_not_installed = False
+    LangfuseTracer._warned_no_credentials = False
+
+
+def _make_tracer_without_credentials() -> None:
+    with patch.dict(
+        'os.environ',
+        {'LANGFUSE_PUBLIC_KEY': '', 'LANGFUSE_SECRET_KEY': ''},
+        clear=False,
+    ):
+        LangfuseTracer(public_key=None, secret_key=None)
+
+
+def test_missing_credentials_warns_once(caplog):
+    with caplog.at_level(logging.DEBUG, logger='axion._core.tracing.langfuse.tracer'):
+        _make_tracer_without_credentials()
+        _make_tracer_without_credentials()
+        _make_tracer_without_credentials()
+
+    matching = [r for r in caplog.records if 'credentials not configured' in r.message]
+    warnings = [r for r in matching if r.levelno == logging.WARNING]
+    debugs = [r for r in matching if r.levelno == logging.DEBUG]
+    assert len(warnings) == 1
+    assert len(debugs) == 2
+
+
+def test_not_installed_warns_once(caplog):
+    with (
+        patch('axion._core.tracing.langfuse.tracer.LANGFUSE_AVAILABLE', False),
+        caplog.at_level(logging.DEBUG, logger='axion._core.tracing.langfuse.tracer'),
+    ):
+        _make_tracer_without_credentials()
+        _make_tracer_without_credentials()
+
+    matching = [r for r in caplog.records if 'not installed' in r.message]
+    warnings = [r for r in matching if r.levelno == logging.WARNING]
+    debugs = [r for r in matching if r.levelno == logging.DEBUG]
+    assert len(warnings) == 1
+    assert len(debugs) == 1


### PR DESCRIPTION
## What

`LangfuseTracer._initialize_client` logged `Langfuse credentials not configured` (and `langfuse package not installed`) at WARNING on **every tracer construction**. A tracer is built per metric instantiation — so a run scoring N deterministic metrics without Langfuse env vars repeats the identical warning N times. Surfaced while wiring echo-workbench's Claude Code session metrics into an API path (6 metrics = 6 identical warnings per session scored, deliberately untraced).

## Fix

Class-level once-per-process flags (same pattern as the existing `_shared_client` class state): first occurrence stays WARNING, subsequent constructions log the same message at DEBUG. Misconfiguration stays discoverable; the spam dies.

## Verification

- `tests/_core/tracing/langfuse/test_warn_once.py` — 3 constructions → exactly 1 WARNING + 2 DEBUG (both branches: no-credentials, not-installed)
- `pytest tests/_core/tracing` — 367 passed
- `pre-commit` (ruff, mypy, absolufy) clean on changed files