### PR TITLE
Attach Langfuse scores in SessionCollection.from_langfuse

### DIFF
--- a/axion/_core/tracing/collection/session.py
+++ b/axion/_core/tracing/collection/session.py
@@ -493,6 +493,9 @@ class Session:
         them to each ``Trace`` via ``trace.scores``.  Requires the loader to have
         valid Langfuse credentials.  Adds roughly one paginated API call regardless
         of session size; fail-soft (errors are logged, scores default to empty).
+        Scores land only on the traces the session still holds, so under
+        ``turns_only=True`` a score attached to a non-turn trace is unreachable;
+        pass ``turns_only=False`` when those traces carry scores you need.
 
         ``turn_name``/``turn_predicate`` set the default turn selector applied by
         ``conversation()``/``to_dataset()``/``turn_count`` (overridable per-call).
@@ -532,13 +535,8 @@ class Session:
             turns_only=turns_only,
         )
 
-        if fetch_scores and hasattr(loader, 'fetch_scores_for_session'):
-            scores_by_trace = loader.fetch_scores_for_session(session_id)
-            for trace in session._traces:
-                tid = str(getattr(trace.raw, 'id', '') or '')
-                trace_scores = scores_by_trace.get(tid, [])
-                if trace_scores:
-                    trace._scores = trace_scores
+        if fetch_scores:
+            _attach_langfuse_scores(session, loader, session_id)
 
         return session
 
@@ -560,6 +558,27 @@ class Session:
         return (
             f"<Session id='{self.id}' traces={len(self._traces)} turns={cached_turns}>"
         )
+
+
+def _attach_langfuse_scores(session: Session, loader: Any, session_id: str) -> None:
+    """
+    Back-fill Langfuse eval scores onto an already-built session's traces.
+
+    Runs after construction because the traces have to exist to be matched by id,
+    which also means a session built with ``turns_only=True`` has already dropped
+    its non-turn traces and those scores have nowhere to land.
+
+    One paginated call per session, and a no-op against a loader that cannot
+    fetch scores, so a caller need not know which loader it holds.
+    """
+    if not hasattr(loader, 'fetch_scores_for_session'):
+        return
+    scores_by_trace = loader.fetch_scores_for_session(session_id)
+    for trace in session._traces:
+        tid = str(getattr(trace.raw, 'id', '') or '')
+        trace_scores = scores_by_trace.get(tid, [])
+        if trace_scores:
+            trace._scores = trace_scores
 
 
 def _build_conversation(

--- a/axion/_core/tracing/collection/session_collection.py
+++ b/axion/_core/tracing/collection/session_collection.py
@@ -5,7 +5,11 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional
 
 from axion._core.logging import get_logger
-from axion._core.tracing.collection.session import Session, TurnPredicate
+from axion._core.tracing.collection.session import (
+    Session,
+    TurnPredicate,
+    _attach_langfuse_scores,
+)
 
 logger = get_logger(__name__)
 
@@ -57,6 +61,7 @@ class SessionCollection:
         prompt_patterns: Any = None,
         show_progress: bool = True,
         enrich: bool = True,
+        fetch_scores: bool = False,
         turn_name: Optional[str] = None,
         turn_predicate: Optional[TurnPredicate] = None,
         turns_only: bool = True,
@@ -83,6 +88,13 @@ class SessionCollection:
                 reconstructable from trace-level I/O, but observation-level access
                 (``by_type``/``tools``/``find_all``) will be empty. Much faster for
                 conversation-only workflows over many sessions.
+            fetch_scores: When ``True``, fetch each session's Langfuse eval scores
+                and attach them to the matching ``Trace`` via ``trace.scores``.
+                Off by default because it costs one extra paginated call per
+                session; without it ``trace.scores`` is empty even though the
+                underlying fetch returned scores, so any metric rolling up
+                per-turn scores silently sees nothing. Scores reach only the
+                traces the session retains -- see ``turns_only``.
             turn_name: Default turn trace name applied to every session's
                 ``conversation()``/``to_dataset()``/``turn_count`` (e.g.
                 ``'chat-turn'``); overridable per-call. Reliable -- bypasses
@@ -120,16 +132,17 @@ class SessionCollection:
             if session_obj is None:
                 logger.warning('Session %s not found; skipping.', session_id)
                 continue
-            sessions.append(
-                Session(
-                    session_obj,
-                    full_traces=full_traces,
-                    prompt_patterns=prompt_patterns,
-                    turn_name=turn_name,
-                    turn_predicate=turn_predicate,
-                    turns_only=turns_only,
-                )
+            session = Session(
+                session_obj,
+                full_traces=full_traces,
+                prompt_patterns=prompt_patterns,
+                turn_name=turn_name,
+                turn_predicate=turn_predicate,
+                turns_only=turns_only,
             )
+            if fetch_scores:
+                _attach_langfuse_scores(session, loader, session_id)
+            sessions.append(session)
 
         return cls(
             sessions,

--- a/docs/guides/langfuse/session-collection.md
+++ b/docs/guides/langfuse/session-collection.md
@@ -76,6 +76,18 @@ sc = SessionCollection.from_langfuse(
 )
 ```
 
+Eval scores are **not** attached unless you ask for them. Without `fetch_scores=True`, `trace.scores` is empty even for traces that carry scores in Langfuse, so a metric rolling up per-trace scores reads nothing and silently produces no value:
+
+```python
+sc = SessionCollection.from_langfuse(
+    session_ids=['session-a', 'session-b'],
+    loader=loader,
+    fetch_scores=True,   # one session-batch API call per session
+)
+```
+
+Scores attach only to the traces a session keeps. With the default `turns_only=True`, non-turn traces are pruned during construction, so scores on those traces are unreachable — pass `turns_only=False` when you need them.
+
 !!! note "Explicit session IDs"
     v1 fetches by explicit `session_ids` only. Not-found ids are **skipped** (logged at WARNING), so the collection contains only sessions that exist.
 
@@ -445,7 +457,7 @@ result.publish_to_observability()
 
 | Method | Description |
 |--------|-------------|
-| `from_langfuse(session_ids, loader, prompt_patterns, show_progress, enrich, turn_name, turn_predicate, turns_only, trace_name, trace_predicate)` | Fetch sessions from Langfuse and wrap |
+| `from_langfuse(session_ids, loader, prompt_patterns, show_progress, enrich, fetch_scores, turn_name, turn_predicate, turns_only, trace_name, trace_predicate)` | Fetch sessions from Langfuse and wrap; `fetch_scores=True` attaches `TraceScore` objects to each trace, one session-batch API call per session |
 | `load_json(path, prompt_patterns, turn_name, turn_predicate, turns_only)` | Load from a JSON file |
 | `filter(condition)` | Filter by lambda, returns new `SessionCollection` |
 | `filter_by(**kwargs)` | Filter by attribute equality |

--- a/tests/_core/tracing/langfuse/test_loader_scores.py
+++ b/tests/_core/tracing/langfuse/test_loader_scores.py
@@ -252,3 +252,124 @@ def test_trace_collection_from_session_fetch_scores_false():
 
     loader.fetch_scores_for_session.assert_not_called()
     assert collection[0].scores == []
+
+
+# ---------------------------------------------------------------------------
+# SessionCollection.from_langfuse — fetch_scores=True
+# ---------------------------------------------------------------------------
+
+
+def _session_loader(scores_by_session):
+    """A loader returning one single-trace session per id, with canned scores."""
+    loader = MagicMock()
+
+    def _get(session_id, **kwargs):
+        raw = SimpleNamespace(
+            id=f'trace-{session_id}', name='dwayne-web-chat', observations=[]
+        )
+        return SimpleNamespace(id=session_id), [raw]
+
+    loader.get_session_with_traces.side_effect = _get
+    loader.fetch_scores_for_session.side_effect = lambda sid: scores_by_session[sid]
+    return loader
+
+
+def test_session_collection_from_langfuse_fetch_scores_attaches_per_session():
+    from axion._core.tracing.collection.session_collection import SessionCollection
+
+    loader = _session_loader(
+        {
+            'sess-1': {
+                'trace-sess-1': [
+                    TraceScore(
+                        name='Dwayne Turn Accuracy', value=0.6, data_type='NUMERIC'
+                    )
+                ]
+            },
+            'sess-2': {
+                'trace-sess-2': [
+                    TraceScore(name='Tool Reliability', value=1.0, data_type='NUMERIC')
+                ]
+            },
+        }
+    )
+
+    collection = SessionCollection.from_langfuse(
+        ['sess-1', 'sess-2'], loader=loader, fetch_scores=True, turns_only=False
+    )
+
+    # One paginated call per session, not per trace.
+    assert loader.fetch_scores_for_session.call_count == 2
+    assert collection[0][0].scores[0].name == 'Dwayne Turn Accuracy'
+    assert collection[1][0].scores[0].value == 1.0
+
+
+def test_session_collection_from_langfuse_defaults_to_no_scores():
+    """The default has to stay off, matching the three sibling constructors.
+
+    This is also the regression: a session-grain metric rolling up per-turn
+    scores saw them empty here while the same traces carried scores everywhere
+    else, so it scored None rather than failing.
+    """
+    from axion._core.tracing.collection.session_collection import SessionCollection
+
+    loader = _session_loader({'sess-1': {}})
+
+    collection = SessionCollection.from_langfuse(
+        ['sess-1'], loader=loader, turns_only=False
+    )
+
+    loader.fetch_scores_for_session.assert_not_called()
+    assert collection[0][0].scores == []
+
+
+def test_session_collection_fetch_scores_reaches_only_retained_traces():
+    """turns_only prunes before the back-fill, so pruned traces keep no scores.
+
+    Documented rather than fixed: the traces have to exist to be matched by id,
+    and widening the back-fill to pruned traces would resurrect what the caller
+    asked to drop.
+    """
+    from axion._core.tracing.collection.session_collection import SessionCollection
+
+    turn = SimpleNamespace(id='trace-turn', name='dwayne-web-chat', observations=[])
+    pipeline = SimpleNamespace(
+        id='trace-pipeline', name='dwayne-pipeline', observations=[]
+    )
+
+    loader = MagicMock()
+    loader.get_session_with_traces.return_value = (
+        SimpleNamespace(id='sess-1'),
+        [turn, pipeline],
+    )
+    loader.fetch_scores_for_session.return_value = {
+        'trace-turn': [TraceScore(name='kept', value=1.0, data_type='NUMERIC')],
+        'trace-pipeline': [TraceScore(name='pruned', value=0.0, data_type='NUMERIC')],
+    }
+
+    collection = SessionCollection.from_langfuse(
+        ['sess-1'],
+        loader=loader,
+        fetch_scores=True,
+        turn_name='dwayne-web-chat',
+        turns_only=True,
+    )
+
+    session = collection[0]
+    assert len(session) == 1
+    assert session[0].scores[0].name == 'kept'
+
+
+def test_session_collection_fetch_scores_noop_on_loader_without_support():
+    """A loader with no score API must not raise — the helper guards on it."""
+    from axion._core.tracing.collection.session_collection import SessionCollection
+
+    raw = SimpleNamespace(id='trace-1', name='dwayne-web-chat', observations=[])
+    loader = MagicMock(spec=['get_session_with_traces'])
+    loader.get_session_with_traces.return_value = (SimpleNamespace(id='sess-1'), [raw])
+
+    collection = SessionCollection.from_langfuse(
+        ['sess-1'], loader=loader, fetch_scores=True, turns_only=False
+    )
+
+    assert collection[0][0].scores == []

--- a/tests/_core/tracing/langfuse/test_loader_scores.py
+++ b/tests/_core/tracing/langfuse/test_loader_scores.py
@@ -265,7 +265,7 @@ def _session_loader(scores_by_session):
 
     def _get(session_id, **kwargs):
         raw = SimpleNamespace(
-            id=f'trace-{session_id}', name='dwayne-web-chat', observations=[]
+            id=f'trace-{session_id}', name='chat-turn', observations=[]
         )
         return SimpleNamespace(id=session_id), [raw]
 
@@ -281,14 +281,12 @@ def test_session_collection_from_langfuse_fetch_scores_attaches_per_session():
         {
             'sess-1': {
                 'trace-sess-1': [
-                    TraceScore(
-                        name='Dwayne Turn Accuracy', value=0.6, data_type='NUMERIC'
-                    )
+                    TraceScore(name='accuracy', value=0.6, data_type='NUMERIC')
                 ]
             },
             'sess-2': {
                 'trace-sess-2': [
-                    TraceScore(name='Tool Reliability', value=1.0, data_type='NUMERIC')
+                    TraceScore(name='reliability', value=1.0, data_type='NUMERIC')
                 ]
             },
         }
@@ -300,7 +298,7 @@ def test_session_collection_from_langfuse_fetch_scores_attaches_per_session():
 
     # One paginated call per session, not per trace.
     assert loader.fetch_scores_for_session.call_count == 2
-    assert collection[0][0].scores[0].name == 'Dwayne Turn Accuracy'
+    assert collection[0][0].scores[0].name == 'accuracy'
     assert collection[1][0].scores[0].value == 1.0
 
 
@@ -332,9 +330,9 @@ def test_session_collection_fetch_scores_reaches_only_retained_traces():
     """
     from axion._core.tracing.collection.session_collection import SessionCollection
 
-    turn = SimpleNamespace(id='trace-turn', name='dwayne-web-chat', observations=[])
+    turn = SimpleNamespace(id='trace-turn', name='chat-turn', observations=[])
     pipeline = SimpleNamespace(
-        id='trace-pipeline', name='dwayne-pipeline', observations=[]
+        id='trace-pipeline', name='pipeline-run', observations=[]
     )
 
     loader = MagicMock()
@@ -351,7 +349,7 @@ def test_session_collection_fetch_scores_reaches_only_retained_traces():
         ['sess-1'],
         loader=loader,
         fetch_scores=True,
-        turn_name='dwayne-web-chat',
+        turn_name='chat-turn',
         turns_only=True,
     )
 
@@ -364,7 +362,7 @@ def test_session_collection_fetch_scores_noop_on_loader_without_support():
     """A loader with no score API must not raise — the helper guards on it."""
     from axion._core.tracing.collection.session_collection import SessionCollection
 
-    raw = SimpleNamespace(id='trace-1', name='dwayne-web-chat', observations=[])
+    raw = SimpleNamespace(id='trace-1', name='chat-turn', observations=[])
     loader = MagicMock(spec=['get_session_with_traces'])
     loader.get_session_with_traces.return_value = (SimpleNamespace(id='sess-1'), [raw])
 


### PR DESCRIPTION
## Problem

`SessionCollection.from_langfuse` is the only one of the four collection constructors without a `fetch_scores` flag. The underlying fetch returns scores populated, but `TraceCollection` builds each `Trace` without them, so `trace.scores` reads empty for every consumer going through this constructor — with no error anywhere.

Verified against a real session: `LangfuseTraceLoader.get_session_with_traces(sid)` returns 8 traces each carrying two scores; the same session through a `SessionCollection` returns 8 traces with `total_scores=0`. The data survives on `trace.raw` but is unreachable through the public accessor.

Any session-grain metric rolling up per-turn scores therefore scores `None`. `Session.from_langfuse`, `TraceCollection.from_langfuse`, and `TraceCollection.from_session` all already take the flag; only this one — the one a session-backed data source reaches for — did not.

## Change

- `SessionCollection.from_langfuse` takes `fetch_scores: bool = False`, back-filling via one `fetch_scores_for_session` call per session (not per trace).
- The back-fill was already duplicated inline in `Session.from_langfuse`; extracted to `_attach_langfuse_scores` so both share one copy rather than adding a third. The helper no-ops on a loader with no score API, so callers need not know which loader they hold.
- Default stays `False` at every hop, matching the three siblings.

## The pruning constraint

Scores reach only the traces a session retains. `turns_only` prunes inside `Session.__init__`, and the back-fill necessarily runs after construction (traces must exist to be matched by id), so a score on a pruned trace has nowhere to land.

Documented on both constructors and covered by a test rather than fixed: widening the back-fill would resurrect traces the caller explicitly asked to drop. Callers who need scores on non-turn traces pass `turns_only=False`.

## Verification

- 1360 passed, full suite.
- 4 new tests. Red-probed: 3 of the 4 fail without the change (`TypeError: unexpected keyword argument 'fetch_scores'`). The 4th passes pre-change by design — it locks the default-off contract.
- `pre-commit` clean on all touched files (ruff-lint, ruff-format, mypy, absolufy-imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)