### PR TITLE
Attach trace-level Langfuse scores when fetch_scores is set

### DIFF
--- a/axion/_core/tracing/collection/scores.py
+++ b/axion/_core/tracing/collection/scores.py
@@ -41,3 +41,49 @@ class TraceScore:
             else None,
             timestamp=getattr(raw, 'timestamp', None),
         )
+
+
+def scores_from_raw_trace(raw: Any) -> list['TraceScore']:
+    """
+    Read eval scores off a raw Langfuse trace payload.
+
+    Returns an empty list when the payload carries no usable scores — a payload
+    whose ``scores`` field holds bare ids rather than score objects reads as
+    empty rather than raising.
+    """
+    parsed: list[TraceScore] = []
+    for raw_score in getattr(raw, 'scores', None) or []:
+        try:
+            parsed.append(TraceScore.from_langfuse(raw_score))
+        except (AttributeError, TypeError, ValueError):
+            continue
+    return parsed
+
+
+def attach_langfuse_scores(traces: Any, loader: Any, session_id: str) -> None:
+    """
+    Back-fill Langfuse eval scores onto already-built traces.
+
+    Runs after construction because the traces have to exist to be matched by id,
+    which also means a session built with ``turns_only=True`` has already dropped
+    its non-turn traces and those scores have nowhere to land.
+
+    Langfuse's session-scoped score query filters on a score's own ``sessionId``,
+    which is unset on a score written against a trace, so that query returns only
+    session-level scores. Per-trace scores are recovered from the trace payload,
+    which already carries them and costs no extra request.
+
+    One paginated call per session, and a no-op against a loader that cannot
+    fetch scores, so a caller need not know which loader it holds.
+    """
+    scores_by_trace: dict[str, list[TraceScore]] = {}
+    if hasattr(loader, 'fetch_scores_for_session'):
+        scores_by_trace = loader.fetch_scores_for_session(session_id)
+
+    for trace in traces:
+        tid = str(getattr(trace.raw, 'id', '') or '')
+        trace_scores = list(scores_by_trace.get(tid, []))
+        if not trace_scores:
+            trace_scores = scores_from_raw_trace(trace.raw)
+        if trace_scores:
+            trace._scores = trace_scores

--- a/axion/_core/tracing/collection/session.py
+++ b/axion/_core/tracing/collection/session.py
@@ -17,6 +17,7 @@ from axion._core.tracing.collection._io import (
     safe_json_load,
 )
 from axion._core.tracing.collection.observation_node import ObservationNode
+from axion._core.tracing.collection.scores import attach_langfuse_scores
 from axion._core.tracing.collection.trace import Trace
 from axion._core.tracing.collection.trace_collection import TraceCollection
 
@@ -488,11 +489,12 @@ class Session:
         input/output -- enough to reconstruct the conversation -- but
         observation-level access (``by_type``/``tools``/``find_all``) will be empty.
 
-        ``fetch_scores`` (default ``False``): when ``True``, fetches all Langfuse
-        eval scores for the session in a single paginated API call and attaches
-        them to each ``Trace`` via ``trace.scores``.  Requires the loader to have
-        valid Langfuse credentials.  Adds roughly one paginated API call regardless
-        of session size; fail-soft (errors are logged, scores default to empty).
+        ``fetch_scores`` (default ``False``): when ``True``, attaches the session's
+        Langfuse eval scores to each ``Trace`` via ``trace.scores``.  Session-level
+        scores come from one paginated API call regardless of session size;
+        trace-level scores are read off the trace payload at no extra request.
+        Requires the loader to have valid Langfuse credentials; fail-soft (errors
+        are logged, scores default to empty).
         Scores land only on the traces the session still holds, so under
         ``turns_only=True`` a score attached to a non-turn trace is unreachable;
         pass ``turns_only=False`` when those traces carry scores you need.
@@ -561,24 +563,8 @@ class Session:
 
 
 def _attach_langfuse_scores(session: Session, loader: Any, session_id: str) -> None:
-    """
-    Back-fill Langfuse eval scores onto an already-built session's traces.
-
-    Runs after construction because the traces have to exist to be matched by id,
-    which also means a session built with ``turns_only=True`` has already dropped
-    its non-turn traces and those scores have nowhere to land.
-
-    One paginated call per session, and a no-op against a loader that cannot
-    fetch scores, so a caller need not know which loader it holds.
-    """
-    if not hasattr(loader, 'fetch_scores_for_session'):
-        return
-    scores_by_trace = loader.fetch_scores_for_session(session_id)
-    for trace in session._traces:
-        tid = str(getattr(trace.raw, 'id', '') or '')
-        trace_scores = scores_by_trace.get(tid, [])
-        if trace_scores:
-            trace._scores = trace_scores
+    """Back-fill Langfuse eval scores onto an already-built session's traces."""
+    attach_langfuse_scores(session._traces, loader, session_id)
 
 
 def _build_conversation(

--- a/axion/_core/tracing/collection/trace_collection.py
+++ b/axion/_core/tracing/collection/trace_collection.py
@@ -14,6 +14,7 @@ from axion._core.tracing.collection._io import (
     extract_trace_io,
 )
 from axion._core.tracing.collection.observation_node import ObservationNode
+from axion._core.tracing.collection.scores import attach_langfuse_scores
 from axion._core.tracing.collection.smart_access import SmartAccess
 from axion._core.tracing.collection.trace import Trace
 
@@ -117,10 +118,10 @@ class TraceCollection:
                 a new one is created from environment variables.
             show_progress: Show a tqdm progress bar while fetching.
             prompt_patterns: Optional PromptPatternsBase for variable extraction.
-            fetch_scores: When ``True``, fetch Langfuse eval scores for the session
-                in a single paginated API call (session-batch path) and attach them
-                to each ``Trace.scores``.  Fail-soft — errors are logged and scores
-                default to empty.
+            fetch_scores: When ``True``, attach the session's Langfuse eval scores
+                to each ``Trace.scores`` — session-level scores from one paginated
+                API call, trace-level scores read off the trace payload at no extra
+                request.  Fail-soft — errors are logged and scores default to empty.
         """
         if loader is None:
             from axion._core.tracing.loaders.langfuse import LangfuseTraceLoader
@@ -130,13 +131,8 @@ class TraceCollection:
         raw_traces = loader.get_session_traces(session_id, show_progress=show_progress)
         collection = cls(raw_traces, prompt_patterns=prompt_patterns)
 
-        if fetch_scores and hasattr(loader, 'fetch_scores_for_session'):
-            scores_by_trace = loader.fetch_scores_for_session(session_id)
-            for trace in collection:
-                tid = str(getattr(trace.raw, 'id', '') or '')
-                trace_scores = scores_by_trace.get(tid, [])
-                if trace_scores:
-                    trace._scores = trace_scores
+        if fetch_scores:
+            attach_langfuse_scores(collection, loader, session_id)
 
         return collection
 

--- a/axion/_core/tracing/loaders/langfuse.py
+++ b/axion/_core/tracing/loaders/langfuse.py
@@ -722,7 +722,11 @@ class LangfuseTraceLoader(BaseTraceLoader):
         self, session_id: str, pace: bool = True
     ) -> 'dict[str, list[TraceScore]]':
         """
-        Fetch all Langfuse eval scores for a session in one paginated call.
+        Fetch a session's Langfuse eval scores in one paginated call.
+
+        The API filters on a score's own ``sessionId``, which is unset on a score
+        written against a trace, so the result covers session-level scores only;
+        per-trace scores come off the trace payload instead.
 
         Returns a dict keyed by ``trace_id`` so callers can attach scores to each
         ``Trace`` without issuing a per-trace request.  On any error the warning is

--- a/docs/guides/langfuse/session-collection.md
+++ b/docs/guides/langfuse/session-collection.md
@@ -86,6 +86,9 @@ sc = SessionCollection.from_langfuse(
 )
 ```
 
+Both kinds of score are covered.
+Langfuse's session-scoped score query returns only scores carrying a `sessionId` of their own, which a score written against a trace does not have; those per-trace scores are read off the trace payload instead, at no extra request.
+
 Scores attach only to the traces a session keeps. With the default `turns_only=True`, non-turn traces are pruned during construction, so scores on those traces are unreachable — pass `turns_only=False` when you need them.
 
 !!! note "Explicit session IDs"

--- a/tests/_core/tracing/langfuse/test_loader_scores.py
+++ b/tests/_core/tracing/langfuse/test_loader_scores.py
@@ -146,7 +146,7 @@ def test_fetch_scores_for_session_error_returns_empty():
 def test_session_from_langfuse_fetch_scores_attaches():
     from axion._core.tracing.collection.session import Session
 
-    raw_trace = SimpleNamespace(id='trace-1', name='abby-web-chat', observations=[])
+    raw_trace = SimpleNamespace(id='trace-1', name='chat-turn', observations=[])
     fake_session = SimpleNamespace(id='sess-1')
 
     loader = MagicMock()
@@ -167,7 +167,7 @@ def test_session_from_langfuse_fetch_scores_attaches():
 def test_session_from_langfuse_fetch_scores_false_leaves_empty():
     from axion._core.tracing.collection.session import Session
 
-    raw_trace = SimpleNamespace(id='trace-1', name='abby-web-chat', observations=[])
+    raw_trace = SimpleNamespace(id='trace-1', name='chat-turn', observations=[])
     fake_session = SimpleNamespace(id='sess-1')
 
     loader = MagicMock()

--- a/tests/_core/tracing/langfuse/test_loader_scores.py
+++ b/tests/_core/tracing/langfuse/test_loader_scores.py
@@ -371,3 +371,72 @@ def test_session_collection_fetch_scores_noop_on_loader_without_support():
     )
 
     assert collection[0][0].scores == []
+
+
+def test_fetch_scores_falls_back_to_scores_on_the_trace_payload():
+    """Langfuse's session score query only returns scores carrying a sessionId.
+
+    A score written against a trace has none, so it is recovered from the trace
+    payload, which already carries it.
+    """
+    from axion._core.tracing.collection.session_collection import SessionCollection
+
+    raw = SimpleNamespace(
+        id='trace-1',
+        name='chat-turn',
+        observations=[],
+        scores=[_raw_score('accuracy', 0.75)],
+    )
+    loader = MagicMock()
+    loader.get_session_with_traces.return_value = (SimpleNamespace(id='sess-1'), [raw])
+    loader.fetch_scores_for_session.return_value = {}
+
+    collection = SessionCollection.from_langfuse(
+        ['sess-1'], loader=loader, fetch_scores=True, turns_only=False
+    )
+
+    scores = collection[0][0].scores
+    assert [(s.name, s.value) for s in scores] == [('accuracy', 0.75)]
+
+
+def test_session_query_scores_take_precedence_over_the_trace_payload():
+    from axion._core.tracing.collection.session_collection import SessionCollection
+
+    raw = SimpleNamespace(
+        id='trace-1',
+        name='chat-turn',
+        observations=[],
+        scores=[_raw_score('accuracy', 0.75)],
+    )
+    loader = MagicMock()
+    loader.get_session_with_traces.return_value = (SimpleNamespace(id='sess-1'), [raw])
+    loader.fetch_scores_for_session.return_value = {
+        'trace-1': [TraceScore(name='accuracy', value=1.0, data_type='NUMERIC')],
+    }
+
+    collection = SessionCollection.from_langfuse(
+        ['sess-1'], loader=loader, fetch_scores=True, turns_only=False
+    )
+
+    assert [s.value for s in collection[0][0].scores] == [1.0]
+
+
+def test_unusable_trace_payload_scores_are_skipped_not_raised():
+    """Some Langfuse payloads carry bare score ids rather than score objects."""
+    from axion._core.tracing.collection.session_collection import SessionCollection
+
+    raw = SimpleNamespace(
+        id='trace-1',
+        name='chat-turn',
+        observations=[],
+        scores=['score-id-1', _raw_score('accuracy', 0.5)],
+    )
+    loader = MagicMock()
+    loader.get_session_with_traces.return_value = (SimpleNamespace(id='sess-1'), [raw])
+    loader.fetch_scores_for_session.return_value = {}
+
+    collection = SessionCollection.from_langfuse(
+        ['sess-1'], loader=loader, fetch_scores=True, turns_only=False
+    )
+
+    assert [s.name for s in collection[0][0].scores] == ['accuracy']


### PR DESCRIPTION
## Problem

`fetch_scores=True` could return no scores at all, without failing.

Every `fetch_scores` path (`Session.from_langfuse`, `TraceCollection.from_langfuse`, `SessionCollection.from_langfuse`) attached scores solely from `loader.fetch_scores_for_session()`, which calls Langfuse's `scores.get_many(session_id=...)`. That endpoint filters on a score's **own** `sessionId` field — which is `None` on a score written against a trace. A project whose eval scores are all trace-level therefore gets `{}` back, `trace.scores` stays `[]`, and any metric rolling up per-trace scores reads nothing and produces no value. The fetch succeeds, so nothing surfaces.

Confirmed against a live Langfuse project:

```
get_many(trace_id=) -> 2 ['<score-a>', '<score-b>']
   score.sessionId = None traceId = '9080ca72804980a5d26ac7e87a46ff5d'
get_many(session_id=) -> 0
```

## Fix

The trace payload already carries its scores, so they are read from there whenever the session query returns nothing for that trace — no extra API call. Session-level scores still take precedence where both exist, so a deployment that does populate `sessionId` is unaffected.

The identical back-fill existed in three places; it now lives in `collection/scores.py` as `attach_langfuse_scores`, importable by both `session.py` and `trace_collection.py` without a cycle.

## Verification

- Live probe against a real project, same 3 sessions / 6 traces: `fetch_scores=True` went from `scores=0` to `scores=10` with the expected score names; `fetch_scores=False` still `0`.
- 3 new unit tests: payload fallback, session-query precedence, and a payload carrying bare score ids (skipped, not raised).
- Full suite: 1363 passed. `ruff check` / `ruff format --check` clean.

## Compatibility

Behavior only widens: a caller that already got scores keeps getting the same ones. `fetch_scores` still defaults to `False`, so no path attaches scores unasked.