### PR TITLE
ToolCorrectness: score precision and f1, not only recall

### DIFF
--- a/axion/metrics/tool/tool_correctness.py
+++ b/axion/metrics/tool/tool_correctness.py
@@ -32,6 +32,14 @@ class ToolCorrectness(BaseMetric):
     - Name-only matching (default): Only tool names must match
     - Parameter matching: Tool names and input parameters must match with various strategies
     - Strict matching: Tool names, parameters, and order must match exactly
+
+    In flexible-order mode the ``scoring`` argument selects what the score
+    measures. The default, ``recall``, answers "were the expected tools called?"
+    and is blind to extra calls: an agent that calls every tool it has scores
+    1.0. ``precision`` answers "were the calls made the expected ones?" and is
+    blind to omissions. ``f1`` requires both. Which one is right depends on what
+    the case is testing — an over-calling agent is invisible to recall, and an
+    agent that skips a required lookup is invisible to precision.
     """
 
     def __init__(
@@ -40,6 +48,7 @@ class ToolCorrectness(BaseMetric):
         strict_order: bool = False,
         parameter_matching_strategy: Literal['exact', 'subset', 'fuzzy'] = 'exact',
         fuzzy_threshold: float = 0.8,
+        scoring: Literal['recall', 'precision', 'f1'] = 'recall',
         **kwargs,
     ):
         """
@@ -53,6 +62,14 @@ class ToolCorrectness(BaseMetric):
                 - "subset": Called args must contain all expected args (can have extras)
                 - "fuzzy": Similarity-based matching with threshold
             fuzzy_threshold: Threshold for fuzzy matching (0.0 to 1.0)
+            scoring: What the flexible-order score measures:
+                - "recall": matched / expected — did it call what was expected
+                  (default; extra calls do not lower the score)
+                - "precision": matched / called — were its calls the expected
+                  ones (missing calls do not lower the score)
+                - "f1": harmonic mean of the two — penalises both
+                Ignored when strict_order is True, which is already all-or-nothing
+                on both counts.
             **kwargs: Additional arguments passed to BaseMetric
         """
         super().__init__(**kwargs)
@@ -60,6 +77,7 @@ class ToolCorrectness(BaseMetric):
         self.strict_order = strict_order
         self.parameter_matching_strategy = parameter_matching_strategy
         self.fuzzy_threshold = fuzzy_threshold
+        self.scoring = scoring
 
     @trace(name='ToolCorrectness.execute', capture_args=True, capture_response=True)
     async def execute(self, item: DatasetItem) -> MetricEvaluationResult:
@@ -158,8 +176,11 @@ class ToolCorrectness(BaseMetric):
             else:
                 missing_or_incorrect.append(expected_tool)
 
-        # The score is recall: number of correctly called tools / number of expected tools.
-        score = len(matched_pairs) / len(expected_tools)
+        score = self._score(
+            matched=len(matched_pairs),
+            expected=len(expected_tools),
+            called=len(tools_called),
+        )
 
         explanation_parts = []
         if matched_pairs:
@@ -188,7 +209,33 @@ class ToolCorrectness(BaseMetric):
         else:
             explanation = '; '.join(explanation_parts)
 
+        # Name the mode in the explanation: the same score means different things
+        # under each, and 'Unexpected tools' appears in the text whether or not
+        # it cost anything.
+        explanation = f'[{self.scoring}] {explanation}'
+
         return score, explanation
+
+    def _score(self, matched: int, expected: int, called: int) -> float:
+        """Combine the match counts into the configured score.
+
+        `expected` is non-zero by the time this is reached — an empty
+        expectation is answered by execute() before any matching happens.
+        `called` can be zero, which is precision's only undefined case: no calls
+        were made, so none of them were wrong. That scores 1.0, and recall
+        carries the failure.
+        """
+        recall = matched / expected
+        if self.scoring == 'recall':
+            return recall
+
+        precision = matched / called if called else 1.0
+        if self.scoring == 'precision':
+            return precision
+
+        if not recall or not precision:
+            return 0.0
+        return 2 * precision * recall / (precision + recall)
 
     def _tools_match(self, called_tool: ToolCall, expected_tool: ToolCall) -> bool:
         """Check if two tools match based on the configured criteria."""

--- a/tests/metrics/tool/test_tool_correctness.py
+++ b/tests/metrics/tool/test_tool_correctness.py
@@ -1,0 +1,155 @@
+import pytest
+
+from axion._core.schema import ToolCall
+from axion.dataset import DatasetItem
+from axion.metrics.tool.tool_correctness import ToolCorrectness
+
+
+def _item(called: list[str], expected: list[str]) -> DatasetItem:
+    return DatasetItem(
+        tools_called=[ToolCall(name=n, args={}) for n in called],
+        expected_tools=[ToolCall(name=n, args={}) for n in expected],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default behaviour — recall, unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_scoring_is_recall():
+    """The default must not move: every existing call site inherits it."""
+    metric = ToolCorrectness()
+    assert metric.scoring == 'recall'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'called, expected, score',
+    [
+        (['a', 'b'], ['a', 'b'], 1.0),
+        (['a'], ['a', 'b'], 0.5),
+        (['x'], ['a', 'b'], 0.0),
+        # The blind spot recall has by construction: three unasked-for calls
+        # alongside the expected one still scores perfect.
+        (['a', 'x', 'y', 'z'], ['a'], 1.0),
+    ],
+)
+async def test_recall_ignores_extra_calls(called, expected, score):
+    result = await ToolCorrectness().execute(_item(called, expected))
+    assert result.score == score
+
+
+# ---------------------------------------------------------------------------
+# Precision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'called, expected, score',
+    [
+        (['a'], ['a'], 1.0),
+        (['a', 'x'], ['a'], 0.5),
+        (['a', 'x', 'y', 'z'], ['a'], 0.25),
+        # Precision's own blind spot, the mirror of recall's: one correct call
+        # and nothing extra is perfect even though a required tool was skipped.
+        (['a'], ['a', 'b'], 1.0),
+    ],
+)
+async def test_precision_penalises_over_calling(called, expected, score):
+    result = await ToolCorrectness(scoring='precision').execute(_item(called, expected))
+    assert result.score == score
+
+
+@pytest.mark.asyncio
+async def test_precision_with_no_calls_made():
+    """No calls means none were wrong, so precision is 1.0 and recall carries it.
+
+    Pinned because the alternative — a ZeroDivisionError — would surface as a
+    metric crash on the most ordinary failure an agent has.
+    """
+    assert (
+        await ToolCorrectness(scoring='precision').execute(_item([], ['a']))
+    ).score == 1.0
+    assert (
+        await ToolCorrectness(scoring='recall').execute(_item([], ['a']))
+    ).score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# F1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'called, expected, score',
+    [
+        (['a', 'b'], ['a', 'b'], 1.0),
+        # precision 1/2, recall 1/1 → 2·.5·1/1.5
+        (['a', 'x'], ['a'], pytest.approx(2 / 3)),
+        # precision 1/1, recall 1/2 → same by symmetry
+        (['a'], ['a', 'b'], pytest.approx(2 / 3)),
+        (['x'], ['a'], 0.0),
+    ],
+)
+async def test_f1_penalises_both_directions(called, expected, score):
+    result = await ToolCorrectness(scoring='f1').execute(_item(called, expected))
+    assert result.score == score
+
+
+@pytest.mark.asyncio
+async def test_f1_is_zero_when_either_term_is_zero():
+    """Guards the harmonic mean's 0/0: precision 1.0 with recall 0.0 must not divide by zero."""
+    result = await ToolCorrectness(scoring='f1').execute(_item([], ['a']))
+    assert result.score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Shared behaviour across modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('scoring', ['recall', 'precision', 'f1'])
+async def test_no_tools_expected_and_none_called_is_correct(scoring):
+    result = await ToolCorrectness(scoring=scoring).execute(_item([], []))
+    assert result.score == 1.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('scoring', ['recall', 'precision', 'f1'])
+async def test_tools_called_when_none_expected_fails(scoring):
+    """Answered before any matching runs, so it is mode-independent."""
+    result = await ToolCorrectness(scoring=scoring).execute(_item(['a'], []))
+    assert result.score == 0.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('scoring', ['recall', 'precision', 'f1'])
+async def test_explanation_names_the_scoring_mode(scoring):
+    """A bare score is ambiguous across modes; the report has to say which one ran."""
+    result = await ToolCorrectness(scoring=scoring).execute(_item(['a', 'x'], ['a']))
+    assert result.explanation.startswith(f'[{scoring}]')
+    assert 'Unexpected tools' in result.explanation
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('scoring', ['recall', 'precision', 'f1'])
+async def test_strict_order_is_unaffected_by_scoring(scoring):
+    """Strict order is already all-or-nothing on both counts, so the mode is inert."""
+    metric = ToolCorrectness(strict_order=True, scoring=scoring)
+    assert (await metric.execute(_item(['a', 'b'], ['a', 'b']))).score == 1.0
+    assert (await metric.execute(_item(['b', 'a'], ['a', 'b']))).score == 0.0
+    assert (await metric.execute(_item(['a', 'b', 'x'], ['a', 'b']))).score == 0.0
+
+
+@pytest.mark.asyncio
+async def test_duplicate_calls_count_once_against_precision():
+    """The same tool called twice matches one expectation; the second is unexpected."""
+    result = await ToolCorrectness(scoring='precision').execute(
+        _item(['a', 'a'], ['a'])
+    )
+    assert result.score == 0.5


### PR DESCRIPTION
## The gap

`_evaluate_flexible_order` scored `matched / expected` — pure recall:

```python
# The score is recall: number of correctly called tools / number of expected tools.
score = len(matched_pairs) / len(expected_tools)
```

So an agent that calls four tools when one was expected scores **1.0**, provided the expected one is among them. Over-calling cannot lower the score in the default mode.

The information needed to catch it was already there. Twenty lines below, `remaining_called` holds exactly the unexpected calls — and was used to build the explanation string and nothing else. This PR scores it.

## The change

A `scoring` argument on `ToolCorrectness`:

- `"recall"` — `matched / expected`. **The default, unchanged.**
- `"precision"` — `matched / called`. Were the calls it made the expected ones.
- `"f1"` — harmonic mean; penalises omissions and extras both.

Ignored under `strict_order=True`, which is already all-or-nothing on both counts.

The default is load-bearing: every existing call site keeps its current numbers, and moving to a stricter mode stays a per-call-site decision. Nothing in this PR changes an existing score.

## Two edges pinned deliberately

**No calls made** → precision `1.0`, not a `ZeroDivisionError`. No calls were made, so none of them were wrong; recall is what carries that failure. The alternative surfaces as a metric crash on the most ordinary way an agent fails.

**Either term zero** → f1 short-circuits to `0.0` rather than evaluating `0/0`.

The explanation now leads with the mode (`[precision] Correctly called: [...]; Unexpected tools: [...]`) because the same number means different things under each, and "Unexpected tools" appears in the text whether or not it cost anything.

## Motivation

Three eval configs carry the same hand-written disclaimer today, e.g.:

> in flexible-order mode the score is pure recall (matched / expected). Extra tools the agent called but nobody expected are named in the explanation and do NOT lower the score, so 1.0 means "called at least these", not "called exactly these".

## Tests

`ToolCorrectness` had **no test coverage at all**. Adds 28 tests: default-is-recall, each mode's arithmetic including its own blind spot, the zero-call and zero-term edges, mode-independence of the empty-expectation paths and of `strict_order`, duplicate calls counting once against precision, and the explanation prefix.

- `pytest tests/metrics/tool/` → 28 passed
- `pytest tests/ -m "not slow"` → 1385 passed, 1 failed
- `pre-commit run --files <changed>` → all passed

The one failure is `tests/caliber/test_pattern_discovery.py::TestPatternDiscoveryMethodDispatch::test_discover_dispatches_to_hybrid`. It is **pre-existing** — verified by stashing this branch's changes and re-running it against clean `master`, where it fails identically ("All retry attempts failed"). Untouched by this PR.